### PR TITLE
WooCommerce 3+ kompatibilitás javítása

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -40,6 +40,9 @@ Igen.
 
 == Changelog ==
 
+= 1.1 =
+* WooCommerce 3+ kompatibilitás javítása
+
 = 1.0 =
 * Elkészült a bővítmény.
 
@@ -47,6 +50,9 @@ Igen.
 * Elkészült a funkció.
 
 == Upgrade Notice ==
+
+= 1.1 =
+* WooCommerce 3+ kompatibilitás javítása
 
 = 1.0 =
 * Elkészült a bővítmény.

--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: -
 Donate link: http://plus-kreativ.hu
 Tags: árukereső, woocommerce, megbízható bolt
 Requires at least: 4.5
-Tested up to: 4.7
-Stable tag: 4.3
+Tested up to: 5.2.2
+Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/public/megbizhato-bolt.php
+++ b/public/megbizhato-bolt.php
@@ -147,15 +147,21 @@ function arukereso_trusted_shop( $order_id ) {
 	$option_name = 'arukereso_webapi_kulcs';
 	$webapikulcs = $wpdb->get_var($wpdb->prepare("SELECT option_value FROM $wpdb->options WHERE option_name = %s", $option_name));
 	$order = wc_get_order( $order_id );
+	$order_data = $order->get_data();
 	
+	/*
+	* Fixing WC 3+ compatibility issues ("Order properties should not be accessed directly.")
+	*
+	* @since    1.1.0
+	*/
 	try {
 		$Client = new TrustedShop($webapikulcs);
-		$kliensmail = $order->billing_email;
+		$kliensmail = $order_data['billing']['email'];
 		$Client->SetEmail($kliensmail);
-		$line_items = $order->get_items();
-		foreach ( $line_items as $item ) {
-			$product = $order->get_product_from_item( $item );
-			$product_name = $item['name'];
+		foreach ($order->get_items() as $line_items => $item ) {
+			$product = $item->get_product();
+			$item_data    = $item->get_data();
+			$product_name = $item_data['name'];
 			$Client->AddProduct($product_name);
 		}
 	echo $Client->Prepare();

--- a/wc-arukereso-megbizthato-bolt.php
+++ b/wc-arukereso-megbizthato-bolt.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Woocommerce Árukereső - Megbízható bolt integráció
  * Plugin URI:        http://plus-kreativ.hu
  * Description:       Árukereső - Megbízható bolt program integrálása Woocommerce rendszerhez
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            Dávid Richárd
  * Author URI:        http://plus-kreativ.hu
  * License:           GPL-2.0+


### PR DESCRIPTION
Sziasztok!

A plugin a WC 3.0 verzió óta elavult módszerrel kérdezte le a webshop rendelés adatait.
E miatt az alábbi figyelmeztetéseket dobálta a WP debug:
"PHP Notice:  billing_email **helytelenül került meghívásra**. Order properties should not be accessed directly. Backtrace: (...) do_action('woocommerce_thankyou'), WP_Hook->do_action, WP_Hook->apply_filters, **arukereso_trusted_shop**, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong..."
Ezt javítottam ebben a commitben.
Kérlek, tegyétek elérhetővé a frissítést a wordpress.org plugin tárában is.

Üdv,
Endre
